### PR TITLE
Notes/Comments

### DIFF
--- a/posts/websockets.md
+++ b/posts/websockets.md
@@ -6,4 +6,4 @@ polyfillurls: [Socket.io](http://socket.io/), [web-socket-js](https://github.com
 
 Making your app real-time is a huge boost and [Socket.io](http://socket.io/) is a Node+Javascript framework that helps with downlevel transports for browsers lacking native websocket support (and supports IE6+). However be prepared to tune your AJAX polling or Comet in order to meet the needs of your app.
 
-As a word of caution, the protocol backing the Web Socket API has changed several times in the past year, but has should have matured enough to not introduce any more breaking changes.
+As a word of caution, the protocol backing the Web Socket API has changed several times in the past year, but has matured enough to not introduce any more breaking changes.


### PR DESCRIPTION
Socket.io is a Node.js framework with a Javascript implementation.  The Javascript API for Socket.io is not a true polyfill as it implements its own API.

web-socket-js is a natural polyfill as it mimics the WebSocket API through Flash Sockets transparently.

I didn't change the grammar, but the WebSocket protocol has reached RFC status (http://tools.ietf.org/html/rfc6455) and will not change (other than planned extension implementations, not affecting the protocol though) unless a security vulnerability is found. I don't think a front-end developer should be concerned with the protocol though, as they work with the API instead (http://dev.w3.org/html5/websockets/).  The API likely won't change much either, but if the protocol did, the developers interaction with the API wouldn't change.

Only Safari currently implements the old Hixie version of the protocol which has been deemed unreliable and insecure.  It's recommended forcing the Flash polyfill over Safari.
