### PR TITLE
Fixed broken link due to parenthesis in url

### DIFF
--- a/posts/cors.md
+++ b/posts/cors.md
@@ -4,4 +4,6 @@ tags: polyfill
 kind: html
 polyfillurls:[postmessage-proxied-xhr](https://github.com/toolness/postmessage-proxied-xhr/#readme), [flXHR](http://flxhr.flensed.com/) (requires crossdomain.xml), [pmxdr](https://github.com/eligrey/pmxdr) (requires host installed)
 
-CORS, or cross-origin resource sharing, enables a few things, but most notably cross-domain AJAX. IE8 introduced [XDomainRequest](http://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx), so really only IE7 needs help with cross-domain files. Consider the polyfills below or you can fallback to using a [simple proxy](http://benalman.com/projects/php-simple-proxy/).
+CORS, or cross-origin resource sharing, enables a few things, but most notably cross-domain AJAX. IE8 introduced [XDomainRequest][], so really only IE7 needs help with cross-domain files. Consider the polyfills below or you can fallback to using a [simple proxy](http://benalman.com/projects/php-simple-proxy/).
+
+[XDomainRequest]: http://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx


### PR DESCRIPTION
Replaced an inline link with a reference-style link in markdown
