### PR TITLE
Added link to the unshimmable subset of ES5. 

### DIFF
--- a/posts/ec.md
+++ b/posts/ec.md
@@ -4,4 +4,8 @@ tags: fallback gtie8 nooldmobile
 kind: js
 polyfillurls: [es5-shim](https://github.com/kriskowal/es5-shim/), [augment.js](http://augmentjs.com/)
 
-ECMAScript version 5 covers a large number of feature additions to what we normally call JavaScript. Excluding IE8, [most of ES5 is supported in browsers](http://kangax.github.com/es5-compat-table/). As it introduces no new syntax, it's possible to polyfill fairly well. The below polyfills tackle most uses of these features, but [not _all_ cases](https://gist.github.com/1120592).
+ECMAScript version 5 covers a large number of feature additions to what we normally call JavaScript. 
+Excluding IE8, [most of ES5 is supported in browsers](http://kangax.github.com/es5-compat-table/). 
+As it introduces no new syntax, it's possible to polyfill fairly well. 
+The below polyfills tackle most uses of these features, but [there is an unshimmable subset of ES5](https://gist.github.com/1664895). 
+Also note that some shims are known to have [edgecase compliance bugs](https://gist.github.com/1120592).


### PR DESCRIPTION
Updated other link to make it emphasize that the issues mentioned are bugs in libraries (not issues with shimmable subsets).

Basically this fix the emphasis of the old link to be "these are known issues at the time of writing" and add new emphasis to that which is the current unshimmable subset of ES5 for some legacy browsers.
