### PR TITLE
Caution note about buggy browser support for soft hyphens.

### DIFF
--- a/posts/hyphens.md
+++ b/posts/hyphens.md
@@ -4,4 +4,4 @@ tags: none prefixes
 kind: css
 polyfillurls:
 
-[CSS Text Level 3](http://dev.w3.org/csswg/css3-text/#hyphenation) allows you to tell the browser to break words using hyphens. As there won't by any noticable effects on browsers which don't support the feature, we recommend that you use it without any polyfills or fallbacks. [CSS Hyphenator](http://code.google.com/p/hyphenator/) is a polyfill that works on browsers that support the soft hyphen. 
+[CSS Text Level 3](http://dev.w3.org/csswg/css3-text/#hyphenation) allows you to tell the browser to break words using hyphens. As there won't by any noticable effects on browsers which don't support the feature, we recommend that you use it without any polyfills or fallbacks. [CSS Hyphenator](http://code.google.com/p/hyphenator/) is a polyfill that works on browsers that support the soft hyphen. When using soft hyphens be aware though that browser support for those might be buggy. Opera for example can't find words containing soft hyphens using page search.


### PR DESCRIPTION
I just tested soft hyphen support in my browsers again and Opera 11.52 still can't find hypenated words on page search. Thought I'd add a caution note about that.
