### PR TITLE
Use WebSockets \o/

### DIFF
--- a/posts/websockets.md
+++ b/posts/websockets.md
@@ -1,5 +1,5 @@
 feature: WebSockets
-status: caution
+status: use
 tags: polyfill 
 kind: api
 polyfillurls: [Socket.io](http://socket.io/), [web-socket-js](https://github.com/gimite/web-socket-js)


### PR DESCRIPTION
As mentioned websockets have an RFC thus are unlikely to change. Caution does not need to be applied anymore.

The only people that need to apply caution are the people implementing the websockets servers on the backend. And that's not us HTML5 guys, we just use websockets and things just work for us. 

Note: websockets are awesome, promote, promote, promote.

Note 2: at this rate:

![HTML5 please use all the things](http://b.static.memegenerator.net/cache/instances/400x/12/13238/13556403.jpg)

Seriously though I don't see good reasons for HTML5 developers to use caution. If there are good reasons we probably want to emphasize them more.
