### PR TITLE
Removed PJAX from polyfill listing, as it is not a polyfill

### DIFF
--- a/posts/history.md
+++ b/posts/history.md
@@ -2,6 +2,6 @@ feature: history
 status: use
 tags: fallback
 kind: api
-polyfillurls:[History.js](https://github.com/balupton/history.js), [pjax](http://pjax.heroku.com/)
+polyfillurls:[History.js](https://github.com/balupton/history.js)
 
-`pushState` gives you real proper URLs along with permalinks to dynamic app state. You can use it and fall back to page refreshes if you'd like. Alternatively, History.js smooths out some browser implementation differences and an and optional hashchange fallback for HTML4 browsers. PJax (pushState + ajax) is what is used by Github for their fallback solution.
+`pushState` gives you real proper URLs along with permalinks to dynamic app state. You can use it and fall back to page refreshes if you'd like. Alternatively, History.js smooths out some browser implementation differences and an and optional hashchange fallback for HTML4 browsers.


### PR DESCRIPTION
Not sure why PJAX was listed as a polyfill as it makes not effort to normalise the HTML5 History API across browsers, it just uses the native HTML5 History API...

This pull request removes the mention of it to avoid this misconception. Alternatively, it could be added as a nice to use library for the native HTML5 History API.
