### PR TITLE
Change safe-to-assume size to 2.5MB for localStorage

### DIFF
--- a/posts/localstorage.md
+++ b/posts/localstorage.md
@@ -6,4 +6,4 @@ polyfillurls:[Remy's storage polyfill](https://gist.github.com/350433), [session
 
 Local and session storage are a great way to store data without resorting to cookies.  IE8 supported `localStorage` and `sessionStorage` so you may not need a polyfill. If you do, Remy's is a piece of cake to implement and use.
 
-This is a simple key/value store, so if you want to store complex data use `JSON.parse(str)` and `JSON.stringify(obj)` on your way in and out. There is also no way to know if you exceeded the storage cross-browser, so wrap your store commands in try/catch. Up to 5MB is safe to use.
+This is a simple key/value store, so if you want to store complex data use `JSON.parse(str)` and `JSON.stringify(obj)` on your way in and out. There is also no way to know if you exceeded the storage cross-browser, so wrap your store commands in try/catch. Up to 2.5MB is safe to use.


### PR DESCRIPTION
In webkit based browsers, desktop as well as mobile, localStorage is sadly only 2.5MBs.

This seems to be due to UTF-16 encoding, see this bug:

http://code.google.com/p/chromium/issues/detail?id=58985#c15

Here's a sweet list of browserscope results for a size test that confirms this:

http://dev-test.nemikor.com/web-storage/support-test/
