### PR TITLE
Encourage use with technologies other than Node.js and socket.io

### DIFF
--- a/posts/websockets.md
+++ b/posts/websockets.md
@@ -2,10 +2,16 @@ feature: WebSockets
 status: caution
 tags: polyfill 
 kind: api
-polyfillurls: [Socket.io](http://socket.io/), [web-socket-js](https://github.com/gimite/web-socket-js)
+polyfillurls: [web-socket-js](https://github.com/gimite/web-socket-js)
 
-Making your app real-time is a huge boost and [Socket.io](http://socket.io/) is a Node+JavaScript framework that helps with downlevel transports for browsers lacking native WebSocket support (and supports IE6+). However be prepared to tune your AJAX polling or Comet in order to meet the needs of your app.
+Adding real-time functionality such as push notifications, activity streams, live-blogging, chat and realtime document collaboration to your app can give it a huge boost through increased interactivity and user engagement.
 
-[web-socket-js](https://github.com/gimite/web-socket-js) is a natural polyfill for the JavaScript WebSocket API transferring data through Flash Sockets when WebSockets aren't available.
+[web-socket-js](https://github.com/gimite/web-socket-js) is a natural polyfill for the JavaScript WebSocket API transferring data through Flash Sockets when WebSockets aren't available. However, be prepared to have an HTTP long-polling, HTTP Streaming or AJAX polling fallback solution for browsers that don't have Flash installed.
+
+There are a number of frameworks that help with fallback transports (HTTP long-polling, HTTP Streaming or AJAX polling) for browsers lacking native WebSocket support. However be prepared to tune your fallback solutions in order to meet the needs of your app.
+
+[Socket.io](http://socket.io/) is a Node+JavaScript framework with native WebSocket support and handles connection fallback (including IE6+ support).
+
+[XSockets](http://xsockets.net/) and  is a .NET+JavaScript framework that handles fallback via Flash and Silverlight.
 
 As a word of caution, the protocol backing the Web Socket API has become an [IETF standard](http://tools.ietf.org/html/rfc6455), but Safari has not yet implemented the new version. It is recommended forcing Flash on Safari (if Flash is available, N/A on mobile), or disabling WebSockets on Safari for now.


### PR DESCRIPTION
The main reason for this commit is that I'm very keen to help developers who don't want to use Node.js, or have a different technology preference, use WebSockets and I think encouraging them to use other back-end technologies (.NET, Ruby, Python) where there are WebSocket server solutions will encourage the uptake of this technology even more.

Details:
- web-socket-js is the most commonly used polyfill so I've updated to mention this first so that the priority is to help developers be able to use the `WebSocket` object within the web page.
- Removed socket.io as a polyfill. It's not a polyfill, it offers a framework that handles connection fallback for you. When using socket.io developers don't then directly use a `WebSocket` object as you do with a polyfill; you use the socket.io client library objects.
- Removed the term 'Comet'. 'tune your Comet' didn't really make sense and Comet is a paradigm, an umbrella term, and Comet servers quite frequently use WebSockets so it's incorrect to say Comet and WebSockets are two different things.
- Added XSockets as a framework with fallback support on a par with socket.io. It doesn't have fallback support beyond Flash and Silverlight so maybe that's a reason not to include it?

I'm maintaining a list of servers with WebSocket support [here](http://www.leggetter.co.uk/real-time-web-technologies-guide#self-hosted) but didn't want to self promote.
