### PR TITLE
<header> and <footer> are not sectioning elements. However <aside> is.

### DIFF
--- a/posts/html5-sectioningelements.md
+++ b/posts/html5-sectioningelements.md
@@ -4,7 +4,7 @@ tags: gtie8,polyfill,article,header,nav
 kind: html
 polyfillurls: [html5shiv](http://code.google.com/p/html5shiv/), [html5shiv (github)](https://github.com/aFarkas/html5shiv/), [accessifyhtml5.js](https://github.com/yatil/accessifyhtml5.js)
 
-All browsers except oldIE (IE <=8) handle new sectioning elements (like `<header>`, `<footer>`, `<nav>`, `<article>`, and `<section>`) fine. However they aren’t always mapped to accessibility APIs as the [HTML5 spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#wai-aria) requires. Currently [only Firefox does this](http://html5accessibility.com/) but other browsers are implementing the a11y APIs quickly. In the meantime, [Accessifyhtml5.js](https://github.com/yatil/accessifyhtml5.js) maps them correctly.
+New sectioning elements (like `<nav>`, `<article>`, `<aside>`, and `<section>`), along with `<header>` and `<footer>`, are handled fine by all browsers except oldIE (IE <=8). However they aren’t always mapped to accessibility APIs as the [HTML5 spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#wai-aria) requires. Currently [only Firefox does this](http://html5accessibility.com/) but other browsers are implementing the a11y APIs quickly. In the meantime, [Accessifyhtml5.js](https://github.com/yatil/accessifyhtml5.js) maps them correctly.
 
 The notes below only apply to oldIE:
 


### PR DESCRIPTION
Technically `<header>` and `<footer>` are not sectioning elements but can be used as header and footer of a section.
I don't know if the wording is clear enough though.
