### PR TITLE
Make the site build on Windows

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -49,8 +49,8 @@ exports.Feature = Backbone.Model.extend({
     if (this.has("contents")) {
       var i, len, parts, key, val, posttags;
       var obj = { contents: '' };
-      var docs = this.get('contents').split('\n\n');
-      var lines = docs[0].split('\n');
+      var docs = this.get('contents').split(/\r\n\r\n|\n\n/);
+      var lines = docs[0].split(/\r\n|\n/);
 
       if(this.has('editfrag')) {
         obj.editurl = paths.githuburl + this.get('editfrag') + '.md';


### PR DESCRIPTION
It seems that Git on Windows has a mechanism to change `LF` to `CRLF` when pulling the code, and back to `LF` when commiting.
This prevents the site from building on Windows since the metadata of each post is extracted by spliting the Markdown content on `LFLF`.
Works on my machine!

http://help.github.com/line-endings/
