### PR TITLE
Added search terms for box sizing and multicolumn.

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
             <footer class="tags">none</footer>
           </article>          
         
-          <article class="fallback prefixes gtie7">
+          <article class="fallback prefixes gtie7 border-box">
             <header>
               <h2 class="name">box-sizing </h2>
               <h3 class="status use">use <i>with <b class=fallback>fallback</b></i> </h3>                                                        
@@ -246,7 +246,7 @@
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/box-sizing.md">Edit this info</a>
               </p>
             </div>
-            <footer class="tags">fallback prefixes gtie7</footer>
+            <footer class="tags">fallback prefixes gtie7 border-box</footer>
           </article>          
         
           <article class="none">
@@ -1220,7 +1220,7 @@ change radically before stabilizing. Avoid using this. </p>
             <footer class="tags">fallback gtie8</footer>
           </article>          
         
-          <article class="prefixes gtie9">
+          <article class="prefixes gtie9 columns">
             <header>
               <h2 class="name">multicolumn </h2>
               <h3 class="status use">use <i></i> </h3>                                                        
@@ -1243,7 +1243,7 @@ change radically before stabilizing. Avoid using this. </p>
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/multicolumn.md">Edit this info</a>
               </p>
             </div>
-            <footer class="tags">prefixes gtie9</footer>
+            <footer class="tags">prefixes gtie9 columns</footer>
           </article>          
         
           <article class="fallback gtie9">

--- a/posts/box-sizing.md
+++ b/posts/box-sizing.md
@@ -1,6 +1,6 @@
 feature: box-sizing
 status: use
-tags: fallback prefixes gtie7
+tags: fallback prefixes gtie7 border-box
 kind: css
 polyfillurls:
 

--- a/posts/multicolumn.md
+++ b/posts/multicolumn.md
@@ -1,6 +1,6 @@
 feature: multicolumn
 status: use
-tags: prefixes gtie9
+tags: prefixes gtie9 columns
 kind: css
 polyfillurls:
 


### PR DESCRIPTION
This pull request adds "border-box" to the tags of "box-sizing" (for those who are searching by the most common value) and "columns" to the tags of "multicolumn" (for those who search for the CSS property).

If this isn't the correct method of attaching meta data for search, are there any suggestions for handling this?
