### PR TITLE
Update posts/form-validation.md

### DIFF
--- a/posts/form-validation.md
+++ b/posts/form-validation.md
@@ -4,4 +4,4 @@ tags: polyfill, gtie9
 kind: html
 polyfillurls: [webshims](http://afarkas.github.com/webshim/demos/), [nwxforms](https://github.com/dperini/nwxforms), [H5F](https://github.com/ryanseddon/H5F)
 
-HTML5 has baked in clientside form validation, and polyfills can enable this for legacy browsers as well. Using the defined HTML5 API for constraint validation may be a more maintainable direction than using a jQuery Validation plugin, depending on your team.
+HTML5 has baked in clientside form validation, and polyfills can enable this for legacy browsers as well. Using the defined HTML5 API for constraint validation may be a more maintainable direction than using a jQuery Validation plugin, depending on your team. When detecting this feature, be aware of Safari's half backed support. It does support the form validation, but don't highlight invalid fields or present error messages.


### PR DESCRIPTION
I believe, we should warn the devs about this pitfall. Modernizr says, Safari supports form validation, but that's just half of the truth.
