### PR TITLE
Is Compass really optional?

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 1. Install Node (with npm): http://nodejs.org/#download
 2. Install Sass: http://sass-lang.com/download.html 
-3. Optionally, install Compass: http://compass-style.org/
+3. Install Compass: http://compass-style.org/
 
 ## Getting Started
 
@@ -22,7 +22,7 @@
 
 4. Each of the features requires its own markdown file under `posts` folder. It is easy to create using the shell script on the parent directory. Just type `./new_feature.sh` and start entering details about the feature you want to add. 
 
-5.  All styles must be in the included `Sass` file rather than be updated in the generated CSS file. Easiest way to compile them is to use [Compass](http://compass-style.org/):
+5.  All styles must be in the included `Sass` file rather than be updated in the generated CSS file. To compile them is to use [Compass](http://compass-style.org/):
 ```
   compass watch .
 ```


### PR DESCRIPTION
You've listed Sass as required (for the stylesheets obviously) and Compass as optional in the readme.

Only, the `.scss` files import some Compass styles, e.g. `@import "compass/css3/gradient";` so won't compile without Compass.  Can this be cleared up in the readme, mark Compass as a requirement perhaps?
