### PR TITLE
Improved wording for box-reflect

### DIFF
--- a/posts/box-reflection.md
+++ b/posts/box-reflection.md
@@ -5,4 +5,4 @@ kind: css
 polyfillurls:
 moreurl: http://www.webkit.org/blog/182/css-reflections/
 
-Box reflection has never been part of a CSS specification. Certain presentations that are possible with `box-reflection` will be possible using CSS Filters. Until then, you should avoid using WebKit-only box reflections.
+The `box-reflect` property has never been part of any CSS specification. Certain presentations that are possible with `-webkit-box-reflect` will be possible using CSS Filters. You should avoid using WebKit-only box reflections.


### PR DESCRIPTION
I didn't care for the wording of this. The word "until" was used, implying that it would later be okay to use box reflections.
