### PR TITLE
Added warning about mobile first

### DIFF
--- a/posts/mediaqueries.md
+++ b/posts/mediaqueries.md
@@ -5,3 +5,5 @@ kind: css
 polyfillurls:
 
 Media Queries (MQ) work on all modern browsers. OldIE (IE6,7,8) unfortunately do not understand media queries on features, which means none of your CSS within media queries will be parsed by them. We recommend you make peace with that (or use Chrome Frame), but if you absolutely cannot, then you can use [Respond.js](https://github.com/scottjehl/Respond)<!--, but be aware it has performance overhead that slows down page load-->.
+
+If you choose a mobile first 'bottom-up' approach where your default styles target the smallest screens first, then be sure to give oldIE <a href="http://jonikorpi.com/leaving-old-IE-behind/">separate styles</a>.


### PR DESCRIPTION
I added this because the main suggestion in this section is to ignore the lack of mq support in oldIE. This would cause problems if the default styles were for mobile.
