### PR TITLE
Removed recommendation to use the geolocation shim polyfill. As far as I...

### DIFF
--- a/posts/geolocation.md
+++ b/posts/geolocation.md
@@ -2,6 +2,6 @@ feature: geolocation
 status: use
 tags: fallback gtie8
 kind: api 
-polyfillurls: [geolocation shim](https://gist.github.com/366184), [geo-location-javascript](http://code.google.com/p/geo-location-javascript/)
+polyfillurls: [geo-location-javascript](http://code.google.com/p/geo-location-javascript/)
 
-[geolocation shim](https://gist.github.com/366184) uses Google's IP-GeoCoding service as a fallback. [geo-location-javascript](http://code.google.com/p/geo-location-javascript/) doesn't but has hooks into BlackBerry, WebOS, and Google Gears specific APIs. In most cases, you should just not expose Geo features in your app if the feature is not natively present.
+[geo-location-javascript](http://code.google.com/p/geo-location-javascript/) has hooks into BlackBerry, WebOS, and Google Gears specific APIs. In most cases, you should just not expose Geo features in your app if the feature is not natively present.


### PR DESCRIPTION
... can tell, google.loader.ClientLocation is no longer supported; it appears to always return null. See http://grokbase.com/t/gg/google-ajax-search-api/126whx58ap/google-loader-api-not-working
