### PR TITLE
Chrome supports input type=color in stable channel

### DIFF
--- a/posts/input-color.md
+++ b/posts/input-color.md
@@ -3,6 +3,6 @@ status: avoid
 tags: polyfill gtie9
 kind: html
 
-A color input will fall back to a plain text input if it's not supported. So far, only Opera and Chrome Canary support this.
+A color input will fall back to a plain text input if it's not supported. So far, only Opera and Chrome support this.
 
 You should probably avoid this until it has support in WebKit, Gecko or IE.


### PR DESCRIPTION
As of Chrome 20. Huzzah. Would still probably avoid it though.
