### PR TITLE
Update posts/cors.md

### DIFF
--- a/posts/cors.md
+++ b/posts/cors.md
@@ -5,5 +5,5 @@ kind: html
 polyfillurls:[flXHR](http://flxhr.flensed.com/) (requires crossdomain.xml)
 
 CORS, or cross-origin resource sharing, enables a few things, but most notably cross-domain AJAX. All non-IE browsers have support for CORS. IE8 introduced [XDomainRequest][], so really only IE7 needs help with cross-domain files. Consider the flXHR polyfill or you can fall back to using a [simple proxy](http://benalman.com/projects/php-simple-proxy/).
-
+N.B.: IE8 and IE9 do not support using [CORS over HTTPS](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx)!
 [XDomainRequest]: http://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx


### PR DESCRIPTION
It should be mentioned that IE8 and IE9 do not let you use CORS if your page is loaded from an HTTPS source.

It's a massive pain in the ass (and definitely caused me several frustrating debugging hours).
