### PR TITLE
Scoped CSS is supported in Firefox 21 Nightly

### DIFF
--- a/posts/scoped-css.md
+++ b/posts/scoped-css.md
@@ -3,4 +3,4 @@ status: avoid
 tags: 
 kind: css
 
-[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. While you can experiment with them in Chrome Canary (type `about:flags` in Chrome's address bar), there is no stable version of any browser supporting this now. 
+[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. While you can experiment with them in Firefox 21 Nightly and Chrome Canary (type `about:flags` in Chrome's address bar), there is no stable version of any browser supporting this now. 


### PR DESCRIPTION
See http://mcc.id.au/blog/2013/01/scoped-style-sheets.
