### PR TITLE
Update posts/animations.md

### DIFF
--- a/posts/animations.md
+++ b/posts/animations.md
@@ -1,7 +1,7 @@
 feature: animations
-status: caution
+status: use
 tags: fallback
 kind: css
 polyfillurls:
 
-CSS Animations are still in flux. The Working Group has [decided to provide](http://www.w3.org/2012/01/13-svg-minutes.html#action02) a universal animation spec that would work across CSS, SVG and HTML. For now, either use animations only to provide non-essential aesthetic enhancements or use feature detection to provide an alternative experience for browsers that do not support this feature.
+Animations are now supported in the latest versions of almost all browsers. In order to provide support for slightly older browsers, either use animations only to provide non-essential aesthetic enhancements or use feature detection to provide an alternative experience for browsers that do not support this feature.


### PR DESCRIPTION
Animations have much better browser support and should be used with fallback now. Opera mini is the only browser that still doesn't support the spec.
