### PR TITLE
fix flensed.com broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@ width: calc(50% - 20px); /** IE and future other browsers **/
               <div class="recco">
                 <p>CORS, or cross-origin resource sharing, enables a few things, but most notably cross-domain AJAX. All non-IE browsers have support for CORS. IE8 introduced <a href="http://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx">XDomainRequest</a>, so really only IE7 needs help with cross-domain files. Consider the flXHR polyfill or you can fall back to using a <a href="http://benalman.com/projects/php-simple-proxy/">simple proxy</a>.</p>
               </div>
-              <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://flxhr.flensed.com/">flXHR</a> (requires crossdomain.xml)</p></div>
+              <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/flensed/flXHR">flXHR</a> (requires crossdomain.xml)</p></div>
 
               <p class="links">
               

--- a/posts/cors.md
+++ b/posts/cors.md
@@ -2,7 +2,7 @@ feature: CORS
 status: use
 tags: polyfill
 kind: html
-polyfillurls:[flXHR](http://flxhr.flensed.com/) (requires crossdomain.xml)
+polyfillurls:[flXHR](https://github.com/flensed/flXHR) (requires crossdomain.xml)
 
 CORS, or cross-origin resource sharing, enables a few things, but most notably cross-domain AJAX. All non-IE browsers have support for CORS. IE8 introduced [XDomainRequest][], so really only IE7 needs help with cross-domain files. Consider the flXHR polyfill or you can fall back to using a [simple proxy](http://benalman.com/projects/php-simple-proxy/).
 


### PR DESCRIPTION
It looks like flensed.com expired. Fortunately, the code for flXHR is on GitHub.
