### PR TITLE
Update masks to reflect new working draft

### DIFF
--- a/posts/masks.md
+++ b/posts/masks.md
@@ -1,9 +1,8 @@
 feature: masks
-status: avoid
+status: caution
 tags: none
 kind: css
 polyfillurls:
-moreurl: http://css3clickchart.com/#masks
+moreurl: http://caniuse.com/css-masks
 
-[CSS Masks](http://www.webkit.org/blog/181/css-masks/) are not being standardized and are unlikely to ever be. CSS Filters might be your path to salvation.
-
+For several years, CSS Masks were a WebKit exclusive. However, they have recently been resuscitated, with the W3C recently publishing a new [Working Draft](http://www.w3.org/TR/css-masking/). Support currently remains limited to WebKit browsers, and SVG-based fallbacks are unwieldy at best, so it may be premature to use this is in a production environment. Still, there may be a future for this feature after all.


### PR DESCRIPTION
The post for css masks doesn't reflect the fact that the feature has gained new life with the advent of the W3C working draft. I suggest changing the status to "caution", but even if you guys are hesitant to do that, I hope you will at least alter the text to reflect the feature's new status (and hopeful future).

By the way, I must be a real dummy, because I can't figure out how you guys add the "View browser share" link to caniuse.com (where applicable), so I just stuck the link in the "moreurl" line. If you merge this commit, please change it so that the caniuse.com link is put in the proper place.
