### PR TITLE
Scoped stylesheets are now in Firefox 21

### DIFF
--- a/posts/scoped-css.md
+++ b/posts/scoped-css.md
@@ -3,4 +3,4 @@ status: avoid
 tags: 
 kind: css
 
-[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. While you can experiment with them in Firefox 21 Nightly and Chrome Canary (type `about:flags` in Chrome's address bar), there is no stable version of any browser supporting this now. 
+[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. While you can experiment with them in Firefox 21 and Chrome Canary (type `about:flags` in Chrome's address bar), there is no stable version of any browser supporting this now. 


### PR DESCRIPTION
See [the Firefox release notes](https://www.mozilla.org/en-US/firefox/21.0/releasenotes/).
