### PR TITLE
added web components

### DIFF
--- a/index.html
+++ b/index.html
@@ -1705,7 +1705,7 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
             </header>
             <div class="more">
               <div class="recco">
-                <p>Pointer events are available in SVG and CSS. All modern browsers support them in SVG, but IE and Opera do not support them in CSS yet. There is a <a href="https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css-pointerevents.js">modernizr plugin</a> to detect support, which can be used to implement a JavaScript interceptor for elements which require pointer events to be disabled.</p>
+                <p>Pointer events are available in SVG and CSS. All modern browsers support them in SVG, but IE and Opera do not support them in CSS yet. There is a <a href="https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/pointerevents.js">modernizr plugin</a> to detect support, which can be used to implement a JavaScript interceptor for elements which require pointer events to be disabled.</p>
               </div>
               <div class="polyfills"></div>
 
@@ -1773,7 +1773,7 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
           
           <article class="polyfill gtie9">
             <header>
-              <h2 class="name" id="&lt;progress&gt;">&lt;progress> </h2>
+              <h2 class="name" id="&amp;lt;progress&gt;">&lt;progress> </h2>
               <h3 class="status use">use <i>with <b class=polyfill>polyfill</b></i> </h3>
               <h4 class="kind html">html</h4>
             </header>
@@ -2245,6 +2245,41 @@ Note that you need to use all the usual prefixes to make this work in all browse
               </p>
             </div>
             <footer class="tags">fallback gtie9</footer>
+          </article>
+          
+          <article class="none">
+            <header>
+              <h2 class="name" id="Web Components">Web Components </h2>
+              <h3 class="status avoid">avoid <i></i> </h3>
+              <h4 class="kind api">api</h4>
+            </header>
+            <div class="more">
+              <div class="recco">
+                <p>The <a href="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/explainer/index.html">Web Components</a> API is a collection of four different specs from the W3C designed to work together: </p>
+
+<ul>
+<li><p><a href="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/templates/index.html">HTML Templates</a>, a native templating system which allows reusable html code using the new &lt;template&gt; tag</p></li>
+<li><p><a href="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html">Custom Elements</a>, which allows authors to define and use custom html elements</p></li>
+<li><p>The <a href="http://www.w3.org/TR/shadow-dom/">Shadow DOM</a>, which allows authors to create an independent new DOM tree nested inside another DOM tree</p></li>
+<li><p><a href="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/imports/index.html">HTML Imports</a>, which allows authors to embed external html files in another html file, using the &lt;link&gt; element</p></li>
+</ul>
+
+<p>Taken together, these proposed specs have the potential to bring huge enhancements to our web development toolkit, but the specs are very immature and currently undergoing rapid iteration. At present, experimental support is only available in Chrome Canary, and any kind of production use is out of the question. However, given the potential benefits Web Components bring to the table, it might be a good idea to start experimenting with the APIs now, and help get constructive feedback and tests back to the spec writers.</p>
+
+<p>The <a href="http://www.polymer-project.org/">Polymer Project</a> is working on a set of polyfills designed to fill any gaps in browser support as Web Components are rolled out. It's still in pre-alpha, and should only be used in testing environments, but if it matures at a healthy rate the project could give us the opportunity to roll Web Components into the wild while the specs are still in draft.</p>
+              </div>
+              <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://www.polymer-project.org/">Polymer Project</a></p></div>
+
+              <p class="links">
+              
+                <a href="http://caniuse.com/webcomponents">
+                  View browser share %
+                </a>
+              
+                <a href="https://github.com/h5bp/html5please/blob/master/posts/webcomponents.md">Edit this info</a>
+              </p>
+            </div>
+            <footer class="tags">none</footer>
           </article>
           
           <article class="fallback gtie9">

--- a/posts/webcomponents.md
+++ b/posts/webcomponents.md
@@ -1,0 +1,19 @@
+feature: Web Components
+status: avoid
+tags: none
+kind: api
+polyfillurls: [Polymer Project](http://www.polymer-project.org/)
+
+The [Web Components](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/explainer/index.html) API is a collection of four different specs from the W3C designed to work together: 
+
+- [HTML Templates](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/templates/index.html), a native templating system which allows reusable html code using the new &lt;template&gt; tag
+
+- [Custom Elements](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html), which allows authors to define and use custom html elements
+
+- The [Shadow DOM](http://www.w3.org/TR/shadow-dom/), which allows authors to create an independent new DOM tree nested inside another DOM tree
+
+- [HTML Imports](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/imports/index.html), which allows authors to embed external html files in another html file, using the &lt;link&gt; element
+
+Taken together, these proposed specs have the potential to bring huge enhancements to our web development toolkit, but the specs are very immature and currently undergoing rapid iteration. At present, experimental support is only available in Chrome Canary, and any kind of production use is out of the question. However, given the potential benefits Web Components bring to the table, it might be a good idea to start experimenting with the APIs now, and help get constructive feedback and tests back to the spec writers.
+
+The [Polymer Project](http://www.polymer-project.org/) is working on a set of polyfills designed to fill any gaps in browser support as Web Components are rolled out. It's still in pre-alpha, and should only be used in testing environments, but if it matures at a healthy rate the project could give us the opportunity to roll Web Components into the wild while the specs are still in draft.


### PR DESCRIPTION
I know that Web Components are certainly not production-worthy, but I found myself trying to look up not just Web Components at html5please.com recently, but also Shadow Dom and HTML Templates. I figured that if I'd tried to do that at the site, so did others, so I thought I'd suggest we add a post for them.

I've chosen to collect all the APIs together under the single Web Components heading, since that term is being bandied about a lot and it makes organization easier. The alternative approach would be to add each of the specs (Shadow Dom, Templates, Custom Elements, and Imports) as separate posts, but my current thinking is that putting all of them under the single Web Components post is better (although I should point out that caniuse.com has Shadow DOM independently-listed and may do so for the other specs when they add them).

Divya suggested Dimitri Glazkov's polyfill at JSConf EU 2012 (and I think elsewhere), but Dimitri himself is now recommending people use Polymer Project (which is ambitious), so that's the polyfill I've chosen to focus on (exclusively) in the post.
