### PR TITLE
Update scoped-css.md

### DIFF
--- a/posts/scoped-css.md
+++ b/posts/scoped-css.md
@@ -3,4 +3,4 @@ status: avoid
 tags: 
 kind: css
 
-[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. While you can experiment with them in Firefox 21 Nightly and Chrome Canary (type `about:flags` in Chrome's address bar), there is no stable version of any browser supporting this now. 
+[Scoped stylesheets](http://css-tricks.com/saving-the-day-with-scoped-css/) are still in active development. Firefox 21 now includes this feature, but no other major browser currently supports it out-the-box.


### PR DESCRIPTION
FF21 now supports this feature (woot!). The previous blurb mentioned a Chrome Canary reference (the "about:flags" bit), but it no longer seems to be valid. I didn't see any reference to scoped CSS, and it wasn't working in Canary.
