### PR TITLE
Specify Safari support for calc()

### DIFF
--- a/posts/calc.md
+++ b/posts/calc.md
@@ -4,11 +4,11 @@ tags: fallback
 kind: css
 polyfillurls:
 
-All the modern browsers except Opera support `calc()` which makes it easier to adopt. But do note that it can have a big impact on the layout and the consequent breaking of your design on unsupported browsers. 
+All the modern browsers except Opera and earlier versions of Safari support `calc()` which makes it easier to adopt. But do note that it can have a big impact on the layout and the consequent breaking of your design on unsupported browsers. 
 
 You should use it with a fallback declaration, so it doesn't break browsers which don't support it.
 
     width: 500px; /** older browsers **/
-    width: -webkit-calc(50% - 20px); /** Chrome / Safari **/
+    width: -webkit-calc(50% - 20px); /** Chrome / Safari 6 **/
     width: -moz-calc(50% - 20px); /** FF 4-15  **/
     width: calc(50% - 20px); /** FF 16+, IE 9+, and future other browsers **/


### PR DESCRIPTION
Safari 5 and earlier don't support calc(). Safari 6 is unavailable to OS X 10.6 and earlier or Windows so the distinction is important
