### PR TITLE
Add info on viewport unit bugs on iOS

### DIFF
--- a/posts/viewport-units.md
+++ b/posts/viewport-units.md
@@ -8,6 +8,7 @@ Viewport units allow elements to be sized proportionally to the browser's viewpo
 
 IE9 supports `vh`, `vw`, and `vm` instead of `vmin` for box and border measurements, but won't size text with viewport units.
 
-Safari on recent iOS versions (6 and 7) has [a serious issue](https://github.com/scottjehl/Device-Bugs/issues/36) with viewport units where entire page width/height is used for relative unit calculation instead of just viewport width/height as described above. This breaks viewport units for dimensions in which the page requires scrolling (e.g. if page height exceeds device height, `vh` units are broken).
+Safari on recent iOS versions (6 and 7) has issues with viewport units where entire page width/height is used for relative unit calculation instead of just viewport width/height as described above (and in the [specification](http://www.w3.org/TR/css3-values/#viewport-relative-lengths)). This causes 
+[serious issues under certain circumstances](https://github.com/scottjehl/Device-Bugs/issues/36) and severely limits the use of viewport units, particularly `vh`.
 
 Depending on the design, it's sometimes possible to gracefully degrade viewport units with approximate fallbacks. Javascript polyfills like [vminpoly](https://github.com/saabi/vminpoly) exist, but aren't recommended on production sites.


### PR DESCRIPTION
There's a serious issue with viewport units on iOS 6 and 7, where they are broken if the page has any content off screen (in other words - if your page requires any scrolling, you won't be able to use these units).

I don't know whether the recommendation status should be changed to _avoid_ because of this, but it should at least be mentioned.
