### PR TITLE
add alt attribute for img element, rm white space from empty lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     </header>
     <div id="main" role="main">
       <section class="features list">
-        
+
           <article class="fallback">
             <header>
               <h2 class="name" id="animations">animations </h2>
@@ -64,17 +64,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/animations">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/animations.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="&lt;audio&gt;">&lt;audio> </h2>
@@ -88,17 +88,17 @@
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://mediaelementjs.com/">mediaelement.js</a>, <a href="https://github.com/happyworm/jPlayer">jPlayer</a>, <a href="http://www.schillmania.com/projects/soundmanager2/">Sound Manager 2</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/audio">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/audio.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="gtie8 fallback">
             <header>
               <h2 class="name" id="background-image options">background-image options </h2>
@@ -112,17 +112,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/background-image">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/background-image.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8 fallback</footer>
           </article>
-          
+
           <article class="fallback prefixes">
             <header>
               <h2 class="name" id="border-image">border-image </h2>
@@ -138,17 +138,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/border-image">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/border-image.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback prefixes</footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="border-radius">border-radius </h2>
@@ -162,17 +162,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/border-radius">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/border-radius.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="box-reflection">box-reflection </h2>
@@ -186,17 +186,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://www.webkit.org/blog/182/css-reflections/">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/box-reflection.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="prefixes">
             <header>
               <h2 class="name" id="box-shadow">box-shadow </h2>
@@ -214,17 +214,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/box-shadow">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/box-shadow.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">prefixes</footer>
           </article>
-          
+
           <article class="fallback prefixes gtie7 border-box">
             <header>
               <h2 class="name" id="box-sizing">box-sizing </h2>
@@ -242,17 +242,17 @@
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/box-sizing">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/box-sizing.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback prefixes gtie7 border-box</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="calc()">calc() </h2>
@@ -274,17 +274,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/calc">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/calc.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="gtie8 polyfill">
             <header>
               <h2 class="name" id="&lt;canvas&gt;">&lt;canvas> </h2>
@@ -302,17 +302,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://flashcanvas.net/">FlashCanvas</a>, <a href="http://code.google.com/p/explorercanvas/">ExplorerCanvas</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/canvas">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/canvas.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8 polyfill</footer>
           </article>
-          
+
           <article class="polyfill noie nooldmobile">
             <header>
               <h2 class="name" id="classList">classList </h2>
@@ -326,17 +326,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/eligrey/classList.js">classlist.js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/classlist">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/classlist.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill noie nooldmobile</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="CORS">CORS </h2>
@@ -350,17 +350,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/flensed/flXHR">flXHR</a> (requires crossdomain.xml)</p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/cors">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/cors.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="prefixes">
             <header>
               <h2 class="name" id="css filters">css filters </h2>
@@ -376,17 +376,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/Schepp/CSS-Filters-Polyfill">Polyfilter - a CSS Filters Polyfill</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://css3clickchart.com/#filters">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/css-filters.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">prefixes</footer>
           </article>
-          
+
           <article class="fallback gtie8">
             <header>
               <h2 class="name" id="css3 colors">css3 colors </h2>
@@ -400,17 +400,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/css3-colors">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/css3-colors.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8</footer>
           </article>
-          
+
           <article class="polyfill gtie9 nomobile">
             <header>
               <h2 class="name" id="&lt;datalist&gt;">&lt;datalist> </h2>
@@ -424,17 +424,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://css-tricks.com/relevant-dropdowns-polyfill-for-datalist/">Relevant Dropdowns</a>, <a href="http://afarkas.github.com/webshim/demos/">Webshims</a>, <a href="http://miketaylr.com/code/datalist.html">jQuery Datalist Plugin</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/datalist">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/datalist.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9 nomobile</footer>
           </article>
-          
+
           <article class="fallback noie nooldmobile">
             <header>
               <h2 class="name" id="dataset">dataset </h2>
@@ -448,17 +448,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://eligrey.com/blog/post/html-5-dataset-support">HTML5 dataset support</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/dataset">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/dataset.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback noie nooldmobile</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="&lt;details&gt;">&lt;details> </h2>
@@ -472,17 +472,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://mathiasbynens.be/notes/html5-details-jquery">Details</a>, <a href="http://akral.bitbucket.org/details-tag">jquery-details</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/details">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/details.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="DOM">DOM </h2>
@@ -498,17 +498,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/termi/ES5-DOM-SHIM">ES5-DOM-shim</a>, <a href="https://github.com/Raynos/DOM-shim">DOM-shim</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/dom">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/dom.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="polyfill nomobile">
             <header>
               <h2 class="name" id="drag n drop">drag n drop </h2>
@@ -522,17 +522,17 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/MrSwitch/dropfile">dropfile</a>, <a href="https://github.com/eligrey/FileSaver.js">fileSaver</a>, <a href="https://github.com/vjeux/jDataView">jDataView</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/dragndrop">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/dragndrop.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill nomobile</footer>
           </article>
-          
+
           <article class="fallback gtie8 nooldmobile es5">
             <header>
               <h2 class="name" id="ECMAScript 5">ECMAScript 5 </h2>
@@ -541,26 +541,26 @@ width: calc(50% - 20px); /** FF 16+, IE 9+, Opera 15, Chrome 26+, Safari 7 and f
             </header>
             <div class="more">
               <div class="recco">
-                <p>ECMAScript version 5 covers a large number of feature additions to what we normally call JavaScript. 
-Excluding IE8, <a href="http://kangax.github.com/es5-compat-table/">most of ES5 is supported in browsers</a>. 
-As it introduces no new syntax, it's possible to polyfill fairly well. 
-The below polyfills tackle most uses of these features, but <a href="https://gist.github.com/1664895">there is an unshimmable subset of ES5</a>. 
+                <p>ECMAScript version 5 covers a large number of feature additions to what we normally call JavaScript.
+Excluding IE8, <a href="http://kangax.github.com/es5-compat-table/">most of ES5 is supported in browsers</a>.
+As it introduces no new syntax, it's possible to polyfill fairly well.
+The below polyfills tackle most uses of these features, but <a href="https://gist.github.com/1664895">there is an unshimmable subset of ES5</a>.
 Also note that some shims are known to have <a href="https://gist.github.com/1120592">edgecase compliance bugs</a>.</p>
               </div>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/kriskowal/es5-shim/">es5-shim</a>, <a href="http://augmentjs.com/">augment.js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/ec">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/ec.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8 nooldmobile es5</footer>
           </article>
-          
+
           <article class="es6">
             <header>
               <h2 class="name" id="ECMAScript 6">ECMAScript 6 </h2>
@@ -578,17 +578,17 @@ Also note that some shims are known to have <a href="https://gist.github.com/112
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://www.2ality.com/2013/07/es6-modules.html">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/es6.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">es6</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="EventSource">EventSource </h2>
@@ -602,17 +602,17 @@ Also note that some shims are known to have <a href="https://gist.github.com/112
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/remy/polyfills/blob/master/EventSource.js">EventSource.js</a>, <a href="https://github.com/rwldrn/jquery.eventsource">jQuery.eventsource</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/Eventsource">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/Eventsource.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="exclusions">exclusions </h2>
@@ -626,17 +626,17 @@ Also note that some shims are known to have <a href="https://gist.github.com/112
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://css3clickchart.com/#exclusions">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/exclusions.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="prefixes polyfill">
             <header>
               <h2 class="name" id="File API">File API </h2>
@@ -658,17 +658,17 @@ Supported in Chrome, Firefox, Opera. Safari is currently missing FileReader supp
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/Jahdrien/FileReader">FileReader</a>, <a href="https://github.com/moxiecode/moxie">moxie</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/fileapi">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/fileapi.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">prefixes polyfill</footer>
           </article>
-          
+
           <article class="prefixes polyfill">
             <header>
               <h2 class="name" id="FileSystem &amp; FileWriter API">FileSystem & FileWriter API </h2>
@@ -685,17 +685,17 @@ Supported only by Chrome 18+ with webkit prefix. Check out <a href="http://caniu
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/ebidel/idb.filesystem.js">idb.filesystem.js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/filesystem">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/filesystem.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">prefixes polyfill</footer>
           </article>
-          
+
           <article class="none flexible">
             <header>
               <h2 class="name" id="flexbox">flexbox </h2>
@@ -711,17 +711,17 @@ Supported only by Chrome 18+ with webkit prefix. Check out <a href="http://caniu
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/flexbox">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/flexbox.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none flexible</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="@font-face">@font-face </h2>
@@ -737,17 +737,17 @@ Supported only by Chrome 18+ with webkit prefix. Check out <a href="http://caniu
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/fontface">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/fontface.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="font-feature-settings">font-feature-settings </h2>
@@ -763,17 +763,17 @@ Supported only by Chrome 18+ with webkit prefix. Check out <a href="http://caniu
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://blog.fontdeck.com/post/15777165734/opentype-1?503cde40">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/font-feature-settings.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="form validation">form validation </h2>
@@ -787,17 +787,17 @@ Supported only by Chrome 18+ with webkit prefix. Check out <a href="http://caniu
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://afarkas.github.com/webshim/demos/">webshims</a>, <a href="https://github.com/dperini/nwxforms">nwxforms</a>, <a href="https://github.com/ryanseddon/H5F">H5F</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/form-validation">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/form-validation.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="FormData API">FormData API </h2>
@@ -837,17 +837,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/formdata">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/formdata.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="fullscreen">fullscreen </h2>
@@ -861,17 +861,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/darcyclarke/jQuery-Fullscreen-Plugin">jQuery Fullscreen Plugin</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/fullscreen">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/fullscreen.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="fallback gtie8">
             <header>
               <h2 class="name" id="geolocation">geolocation </h2>
@@ -885,17 +885,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://code.google.com/p/geo-location-javascript/">geo-location-javascript</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/geolocation">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/geolocation.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8</footer>
           </article>
-          
+
           <article class="fallback prefixes gtie8">
             <header>
               <h2 class="name" id="gradients">gradients </h2>
@@ -911,17 +911,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/gradients">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/gradients.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback prefixes gtie8</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="grids">grids </h2>
@@ -935,17 +935,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/grids">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/grids.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="history">history </h2>
@@ -959,17 +959,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/history">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/history.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="gtie8 polyfill">
             <header>
               <h2 class="name" id="HTML5 elements">HTML5 elements </h2>
@@ -991,17 +991,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://code.google.com/p/html5shiv/">html5shiv</a>, <a href="https://github.com/aFarkas/html5shiv/">html5shiv (github)</a>, <a href="https://github.com/yatil/accessifyhtml5.js">accessifyhtml5.js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/html5semantic">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/html5semantic.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8 polyfill</footer>
           </article>
-          
+
           <article class="none prefixes">
             <header>
               <h2 class="name" id="hyphens">hyphens </h2>
@@ -1018,17 +1018,17 @@ to build the body, whereas FormData sends packets.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/hyphens">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/hyphens.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none prefixes</footer>
           </article>
-          
+
           <article class="gtie9">
             <header>
               <h2 class="name" id="iframe[sandbox]">iframe[sandbox] </h2>
@@ -1049,17 +1049,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/iframe-sandbox">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/iframe-sandbox.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie9</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="iframe[seamless]">iframe[seamless] </h2>
@@ -1083,17 +1083,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://weblog.bocoup.com/third-party-javascript-development-future/#iframe-seamless">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/iframe-seamless.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="iframe[srcdoc]">iframe[srcdoc] </h2>
@@ -1111,17 +1111,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/jugglinmike/srcdoc-polyfill">srcdoc polyfill</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://weblog.bocoup.com/third-party-javascript-development-future/#iframe-srcdoc">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/iframe-srcdoc.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="fallback gtie8">
             <header>
               <h2 class="name" id="IndexedDB">IndexedDB </h2>
@@ -1132,23 +1132,23 @@ defense-in-depth strategy.</p>
               <div class="recco">
                 <p>IndexedDB was a volatile spec for a year, but has settled down. Chrome, Firefox, Opera and IE10 have shipped it. Safari has not yet committed to it.</p>
 
-<p>The <a href="http://nparashuram.com/IndexedDBShim">IndexedDB Polyfill</a> is a polyfill for the IndexedDB APIs over WebSql. This enables IndexedDB to work on browsers that support WebSql. 
+<p>The <a href="http://nparashuram.com/IndexedDBShim">IndexedDB Polyfill</a> is a polyfill for the IndexedDB APIs over WebSql. This enables IndexedDB to work on browsers that support WebSql.
 <a href="https://github.com/jensarps/IDBWrapper">IDBWrapper</a> helps smooth out the cross-browser differences. You may consider falling back to WebSQL when IndexedDB isn't available, but do keep in mind that WebSQL has been abandoned.</p>
               </div>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/jensarps/IDBWrapper">IDBWrapper</a>, <a href="http://nparashuram.com/IndexedDBShim">IndexedDB Polyfill</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/indexeddb">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/indexeddb.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="&lt;input type=color&gt;">&lt;input type=color> </h2>
@@ -1164,17 +1164,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/input-color">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-color.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="&lt;input type=date&gt;">&lt;input type=date> </h2>
@@ -1192,17 +1192,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://afarkas.github.com/webshim/demos/demos/webforms.html">webshims</a>, <a href="http://www.useragentman.com/blog/2010/07/27/cross-browser-html5-forms-using-modernizr-webforms2-and-html5widgets/">html5widgets</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/input-datetime">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-datetime.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="polyfill fallback">
             <header>
               <h2 class="name" id="&lt;input type=number&gt;">&lt;input type=number> </h2>
@@ -1220,17 +1220,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/jonstipe/number-polyfill">Number polyfill</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/input-number">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-number.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill fallback</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="&lt;input type=range&gt;">&lt;input type=range> </h2>
@@ -1248,17 +1248,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://www.frequency-decoder.com/2010/11/18/unobtrusive-slider-control-html5-input-range-polyfill/">Input Range Polyfill</a>, <a href="https://github.com/fryn/html5slider">html5slider</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/input-range">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-range.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="&lt;input type=search&gt;">&lt;input type=search> </h2>
@@ -1276,17 +1276,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://www.wufoo.com/html5/types/5-search.html">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-search.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="gtie9">
             <header>
               <h2 class="name" id="input[placeholder]">input[placeholder] </h2>
@@ -1308,17 +1308,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/mathiasbynens/jquery-placeholder">Placeholder jQuery Plugin</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/input-placeholder">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/input-placeholder.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie9</footer>
           </article>
-          
+
           <article class="gtie7 polyfill">
             <header>
               <h2 class="name" id="JSON">JSON </h2>
@@ -1336,17 +1336,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/douglascrockford/JSON-js">json2.js</a>, <a href="http://bestiejs.github.com/json3/">JSON 3</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/json">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/json.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie7 polyfill</footer>
           </article>
-          
+
           <article class="gtie7 polyfill">
             <header>
               <h2 class="name" id="localStorage">localStorage </h2>
@@ -1366,17 +1366,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://gist.github.com/350433">Remy’s storage polyfill</a>, <a href="http://code.google.com/p/sessionstorage/">sessionstorage</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/localstorage">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/localstorage.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie7 polyfill</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="masks">masks </h2>
@@ -1390,17 +1390,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/masks">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/masks.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="matchMedia">matchMedia </h2>
@@ -1414,17 +1414,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/matchmedia">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/matchmedia.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="gtie8">
             <header>
               <h2 class="name" id="media queries">media queries </h2>
@@ -1440,17 +1440,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/mediaqueries">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/mediaqueries.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8</footer>
           </article>
-          
+
           <article class="polyfill noie nomobile">
             <header>
               <h2 class="name" id="&lt;menu&gt;">&lt;menu> </h2>
@@ -1464,17 +1464,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/medialize/jQuery-contextMenu">contextMenu</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/menu">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/menu.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill noie nomobile</footer>
           </article>
-          
+
           <article class="polyfill noie nomobile">
             <header>
               <h2 class="name" id="&lt;meter&gt;">&lt;meter> </h2>
@@ -1483,22 +1483,22 @@ defense-in-depth strategy.</p>
             </header>
             <div class="more">
               <div class="recco">
-                
+
               </div>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://gist.github.com/667320">meter-polyfill</a>, <a href="https://github.com/xjamundx/HTML5-Meter-Shim">jQuery shim</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/meter">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/meter.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill noie nomobile</footer>
           </article>
-          
+
           <article class="polyfill ie6 gtie6">
             <header>
               <h2 class="name" id="Microdata DOM API">Microdata DOM API </h2>
@@ -1518,17 +1518,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/termi/Microdata-JS">microdata shim</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://dev.opera.com/articles/view/microdata-and-the-microdata-dom-api/">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/microdata-domapi.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill ie6 gtie6</footer>
           </article>
-          
+
           <article class="gtie6">
             <header>
               <h2 class="name" id="min/max-width/height">min/max-width/height </h2>
@@ -1544,17 +1544,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/minmaxwh">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/minmaxwh.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie6</footer>
           </article>
-          
+
           <article class="prefixes gtie9 columns">
             <header>
               <h2 class="name" id="multicolumn">multicolumn </h2>
@@ -1570,17 +1570,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/multicolumn">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/multicolumn.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">prefixes gtie9 columns</footer>
           </article>
-          
+
           <article class="fallback gtie8">
             <header>
               <h2 class="name" id="multiple backgrounds">multiple backgrounds </h2>
@@ -1594,17 +1594,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/multibackgrounds">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/multibackgrounds.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8</footer>
           </article>
-          
+
           <article class="fallback gtie9">
             <header>
               <h2 class="name" id="offline">offline </h2>
@@ -1618,17 +1618,17 @@ defense-in-depth strategy.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/offline">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/offline.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie9</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="ol[reversed]">ol[reversed] </h2>
@@ -1643,17 +1643,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://gist.github.com/1671548">ol reversed polyfill</a>, <a href="https://github.com/impressivewebs/HTML5-Reverse-Ordered-Lists">HTML5 reverse ordered lists</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://html5doctor.com/ol-element-attributes/#reverse">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/ol-reversed.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="gtie8">
             <header>
               <h2 class="name" id="opacity">opacity </h2>
@@ -1667,17 +1667,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/opacity">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/opacity.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="paged media">paged media </h2>
@@ -1691,17 +1691,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://css3clickchart.com/#paged-media">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/paged-media.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="fallback noie">
             <header>
               <h2 class="name" id="pointer events">pointer events </h2>
@@ -1717,17 +1717,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/pointer-events">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/pointer-events.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback noie</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="position:fixed">position:fixed </h2>
@@ -1743,17 +1743,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/css-fixed">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/css-fixed.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="api">
             <header>
               <h2 class="name" id="postMessage">postMessage </h2>
@@ -1767,17 +1767,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://easyxdm.net/wp/">EasyXDM</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/postmessage">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/postmessage.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">api</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="&amp;lt;progress&gt;">&lt;progress> </h2>
@@ -1792,17 +1792,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/progress">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/progress.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="pseudo elements">pseudo elements </h2>
@@ -1818,17 +1818,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/pseudo-elements">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/pseudo-elements.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="regions">regions </h2>
@@ -1842,17 +1842,17 @@ Also see <a href="http://www.impressivewebs.com/reverse-ordered-lists-html5/">Lo
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/regions">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/regions.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="fallback gtie8">
             <header>
               <h2 class="name" id="rem unit">rem unit </h2>
@@ -1869,17 +1869,17 @@ by Johnathan Snook</a>.</p>
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/rem">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/rem.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie8</footer>
           </article>
-          
+
           <article class="polyfill gtie9">
             <header>
               <h2 class="name" id="requestAnimationFrame">requestAnimationFrame </h2>
@@ -1897,17 +1897,17 @@ by Johnathan Snook</a>.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://gist.github.com/1579671">requestAnimationFrame polyfill</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/requestanimationframe">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/requestanimationframe.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="&lt;ruby&gt;">&lt;ruby> </h2>
@@ -1921,17 +1921,17 @@ by Johnathan Snook</a>.</p>
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://www.useragentman.com/blog/2010/10/29/cross-browser-html5-ruby-annotations-using-css/">Cross-browser Ruby</a>, <a href="http://sideshowbarker.net/2009/11/13/html5-ruby/#comment-3388">basic fallback</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/ruby">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/ruby.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="fallback gtie6">
             <header>
               <h2 class="name" id="selectors">selectors </h2>
@@ -1992,17 +1992,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/selectors">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/selectors.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie6</footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="style[scoped]">style[scoped] </h2>
@@ -2016,17 +2016,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://css-tricks.com/saving-the-day-with-scoped-css/">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/scoped-css.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="@supports">@supports </h2>
@@ -2044,17 +2044,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/supports">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/supports.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="gtie8 polyfill">
             <header>
               <h2 class="name" id="&lt;svg&gt;">&lt;svg> </h2>
@@ -2070,17 +2070,17 @@ Resources:
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://code.google.com/p/svgweb/">SVGWeb</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/svg">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/svg.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie8 polyfill</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="text-overflow">text-overflow </h2>
@@ -2094,17 +2094,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/text-overflow">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/text-overflow.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="gtie9">
             <header>
               <h2 class="name" id="text-shadow">text-shadow </h2>
@@ -2120,17 +2120,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/text-shadow">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/text-shadow.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">gtie9</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="text-stroke">text-stroke </h2>
@@ -2144,17 +2144,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/text-stroke">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/text-stroke.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="polyfill gtie9 webvtt">
             <header>
               <h2 class="name" id="&lt;track&gt;">&lt;track> </h2>
@@ -2168,17 +2168,17 @@ Resources:
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://captionatorjs.com/">captionator.js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="https://developer.mozilla.org/en/HTML/Element/track#Compatibility">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/track.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie9 webvtt</footer>
           </article>
-          
+
           <article class="fallback prefixes">
             <header>
               <h2 class="name" id="transforms">transforms </h2>
@@ -2192,17 +2192,17 @@ Resources:
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/transforms">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/transforms.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback prefixes</footer>
           </article>
-          
+
           <article class="fallback prefixes">
             <header>
               <h2 class="name" id="transitions">transitions </h2>
@@ -2217,17 +2217,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/transitions">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/transitions.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback prefixes</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="Vibration">Vibration </h2>
@@ -2247,17 +2247,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="https://developer.mozilla.org/en-US/docs/WebAPI/Vibration">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/vibration.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
           <article class="polyfill gtie8">
             <header>
               <h2 class="name" id="&lt;video&gt;">&lt;video> </h2>
@@ -2273,17 +2273,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://mediaelementjs.com/">mediaelementjs</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/video">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/video.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill gtie8</footer>
           </article>
-          
+
           <article class="fallback gtie9">
             <header>
               <h2 class="name" id="Viewport units (vh, vw, vmin, vmax)">Viewport units (vh, vw, vmin, vmax) </h2>
@@ -2301,17 +2301,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/viewport-units">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/viewport-units.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie9</footer>
           </article>
-          
+
           <article class="polyfill">
             <header>
               <h2 class="name" id="Web Components">Web Components </h2>
@@ -2341,17 +2341,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://www.polymer-project.org/">Polymer</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://www.webcomponentsshift.com/">
                   Learn more
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/webcomponents.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill</footer>
           </article>
-          
+
           <article class="fallback gtie9">
             <header>
               <h2 class="name" id="Web Workers">Web Workers </h2>
@@ -2365,17 +2365,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/webworkers">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/webworkers.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback gtie9</footer>
           </article>
-          
+
           <article class="fallback">
             <header>
               <h2 class="name" id="WebGL">WebGL </h2>
@@ -2391,17 +2391,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/webgl">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/webgl.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">fallback</footer>
           </article>
-          
+
           <article class="">
             <header>
               <h2 class="name" id="WebP">WebP </h2>
@@ -2419,17 +2419,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="http://webpjs.appspot.com/">WebPJS</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/webp">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/webp.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags"></footer>
           </article>
-          
+
           <article class="polyfill prefixes">
             <header>
               <h2 class="name" id="WebSockets">WebSockets </h2>
@@ -2461,17 +2461,17 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"><b>Recommended polyfills: </b><p><a href="https://github.com/gimite/web-socket-js">web-socket-js</a></p></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/websockets">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/websockets.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">polyfill prefixes</footer>
           </article>
-          
+
           <article class="none">
             <header>
               <h2 class="name" id="WebSQL DB">WebSQL DB </h2>
@@ -2485,23 +2485,23 @@ Note that you need to use all the usual prefixes to make this work in all browse
               <div class="polyfills"></div>
 
               <p class="links">
-              
+
                 <a href="http://caniuse.com/websql">
                   View browser share %
                 </a>
-              
+
                 <a href="https://github.com/h5bp/html5please/blob/master/posts/websql.md">Edit this info</a>
               </p>
             </div>
             <footer class="tags">none</footer>
           </article>
-          
+
         </section>
       <h2 id="noitems" class="visuallyhidden">No items met your search =(</h2>
     </div>
     <footer>
       <p>HTML5 Please is a community project (<a href="https://github.com/h5bp/html5please/">contribute on github!</a>) from the people behind <a href="http://html5boilerplate.com">HTML5 Boilerplate</a>, <a href="http://modernizr.com">Modernizr</a> &amp; <a href="http://css3please.com">CSS3 Please</a>.</p>
-      <p class="builders"> <a href="http://twitter.com/divya"><img src="https://twitter.com/api/users/profile_image/divya?size=normal" alt="Divya Manian"><b>Divya</b> Manian</a> <a href="http://twitter.com/paul_irish"><img src="https://twitter.com/api/users/profile_image/paul_irish?size=normal" alt="Paul Irish"><b>Paul</b> Irish</a> <a href="http://twitter.com/tbranyen"><img src="https://twitter.com/api/users/profile_image/tbranyen?size=normal" alt="Tim Branyen"><b>Tim</b> Branyen</a> <a href="http://twitter.com/connor"><img src="https://twitter.com/api/users/profile_image/connor?size=normal" alt="Connor Montgomery"><b>Connor</b> Montgomery</a> <a href="http://raynos.org/blog/"><img src="http://gravatar.com/avatar/d840cb1fb7e828284011cc08f40a1015?s=48"><b>Jake</b> Verbaten</a> <a href="https://github.com/h5bp/html5please/contributors">&amp; more</a>
+      <p class="builders"> <a href="http://twitter.com/divya"><img src="https://twitter.com/api/users/profile_image/divya?size=normal" alt="Divya Manian"><b>Divya</b> Manian</a> <a href="http://twitter.com/paul_irish"><img src="https://twitter.com/api/users/profile_image/paul_irish?size=normal" alt="Paul Irish"><b>Paul</b> Irish</a> <a href="http://twitter.com/tbranyen"><img src="https://twitter.com/api/users/profile_image/tbranyen?size=normal" alt="Tim Branyen"><b>Tim</b> Branyen</a> <a href="http://twitter.com/connor"><img src="https://twitter.com/api/users/profile_image/connor?size=normal" alt="Connor Montgomery"><b>Connor</b> Montgomery</a> <a href="http://raynos.org/blog/"><img src="http://gravatar.com/avatar/d840cb1fb7e828284011cc08f40a1015?s=48" alt="Jake Verbaten"><b>Jake</b> Verbaten</a> <a href="https://github.com/h5bp/html5please/contributors">&amp; more</a>
       </p>
     </footer>
 


### PR DESCRIPTION
- add alt attribute for img element (the analogous elements on the page already have an alt attribute)
- rm white space characters from empty lines, just a newline will do (didn't do this on purpose, but I have my editor set to do it, so what the hey, save a byte or three)
