### PR TITLE
Fixed freqdec's Input Range Polyfill url

### DIFF
--- a/posts/input-range.md
+++ b/posts/input-range.md
@@ -2,10 +2,10 @@ feature: <input type=range>
 status: caution
 tags: polyfill gtie9
 kind: html
-polyfillurls: [Input Range Polyfill](http://www.frequency-decoder.com/2010/11/18/unobtrusive-slider-control-html5-input-range-polyfill/), [html5slider](https://github.com/fryn/html5slider)
+polyfillurls: [Input Range Polyfill](https://github.com/freqdec/fd-slider), [html5slider](https://github.com/fryn/html5slider)
 
 A range input (AKA slider) will fall back to a plain text input if it's not supported.
 
-You can use freqdec's [Input Range Polyfill](http://www.frequency-decoder.com/2010/11/18/unobtrusive-slider-control-html5-input-range-polyfill/). Or to support Firefox <= 22, try Frank Yan's [html5slider](https://github.com/fryn/html5slider).
+You can use freqdec's [Input Range Polyfill](https://github.com/freqdec/fd-slider). Or to support Firefox <= 22, try Frank Yan's [html5slider](https://github.com/fryn/html5slider).
 
 These polyfills aren't drop-in polyfills, and you'll need to wire them up a little, but your markup can depend on `<input type=range>` creating a slider.


### PR DESCRIPTION
Seems like that the [current url](http://www.frequency-decoder.com/2010/11/18/unobtrusive-slider-control-html5-input-range-polyfill/) doesn't exist any more so I updated it to the [github repo](https://github.com/freqdec/fd-slider).
