### PR TITLE
recommend Spectrum as <input type="color"> polyfill

### DIFF
--- a/posts/input-color.md
+++ b/posts/input-color.md
@@ -2,6 +2,7 @@ feature: <input type=color>
 status: avoid
 tags: polyfill gtie9
 kind: html
+polyfillurls: [Spectrum](https://github.com/bgrins/spectrum)
 
 A color input will fall back to a plain text input if it's not supported. So far, only Opera and Chrome support this.
 


### PR DESCRIPTION
Why? Because:
- It's actively maintained
- [It was good enough to get added to WebKit/Blink's dev tools](http://bgrins.github.io/spectrum/#why-devtools)
- It's MIT-licensed
- It's widely compatible (IE 6+)
- It has CI and a test suite set up
- It has an issue tracker (one of its competitors doesn't)

By recommending specific polyfill(s), you save people the time+effort of having to research+compare the various polyfill options themselves.
