### PR TITLE
remove <ruby> "basic fallback" link (returns 404)

### DIFF
--- a/posts/ruby.md
+++ b/posts/ruby.md
@@ -2,6 +2,6 @@ feature: <ruby>
 status: use
 tags: fallback
 kind: html
-polyfillurls: [Cross-browser Ruby](http://www.useragentman.com/blog/2010/10/29/cross-browser-html5-ruby-annotations-using-css/), [basic fallback](http://sideshowbarker.net/2009/11/13/html5-ruby/#comment-3388)
+polyfillurls: [Cross-browser Ruby](http://www.useragentman.com/blog/2010/10/29/cross-browser-html5-ruby-annotations-using-css/)
 
 If you are using the Ruby element you don't need a script-based fallback, but you can provide a CSS-based set of good defaults.


### PR DESCRIPTION
http://sideshowbarker.net/2009/11/13/html5-ruby/#comment-3388 - 404
http://sideshowbarker.net/ - redirects to google+
