### PR TITLE
update browser support for File API

### DIFF
--- a/posts/fileapi.md
+++ b/posts/fileapi.md
@@ -7,7 +7,7 @@ polyfillurls: [FileReader](https://github.com/Jahdrien/FileReader), [moxie](http
 Using the File API added to the DOM in HTML5, it's now possible for web content to ask the user to select local files.
 
 FileReader pairs very well with Drag n Drop to allow for drag 'n drop file uploads, and if neither of those features are present, the fallback of providing an `<input type=file>` is rather easy.
-Supported in Chrome, Firefox, Opera. Safari is currently missing FileReader support.
+Fully supported in Chrome, Firefox, Opera, Safari 6 and IE 10. Partially supported in Safari 5.1 (lacks FileReader support).
 
 * [FileReader](https://github.com/Jahdrien/FileReader) provides useful fallback, based on Flash, jQuery and jQuery UI.  Doesn't support readAsBinaryFile.
 * [moxie](https://github.com/moxiecode/moxie) extracted from Plupload, actively maintained as of 6/3/13.


### PR DESCRIPTION
The File API has been supported in Safari since version 5.1 and IE since version 10.
