### PR TITLE
Remove link to favicon in `index.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Look up HTML5, CSS3, etc features, know if they are ready for use, and if so find out how you should use them – with polyfills, fallbacks or as they are.">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-    <link rel="shortcut icon" href="favicon.ico" />
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="apple-touch-icon-114x114-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="apple-touch-icon-72x72-precomposed.png">
     <link rel="apple-touch-icon-precomposed" href="apple-touch-icon-precomposed.png">


### PR DESCRIPTION
It isn't needed to include a <link> tag for the favicon, since it's in the root directory the browser will find it by itself.

Including this totally not needed tag is just wasting bytes.
