### PR TITLE
Remove all references to html5please.us

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-html5please.us

--- a/template.html
+++ b/template.html
@@ -14,7 +14,7 @@
     <link href="http://fonts.googleapis.com/css?family=Francois+One|Open+Sans:400italic,400,800" rel="stylesheet">
     <link href="css/style.css" rel="stylesheet">
     <script src="js/libs/modernizr-2.0.min.js"></script>
-    <script>if (location.host == 'h5bp.github.com') location.href = '//html5please.us/'</script>
+    <script>if (location.host == 'h5bp.github.com') location.href = '//html5please.com/'</script>
 
 
   </head>


### PR DESCRIPTION
Since [html5please.us](http://html5please.us) isn't a canonical for html5please.com anymore, all references to it in the codebase must be removed. The repo description was already changed with https://github.com/h5bp/html5please/issues/299.
