### PR TITLE
don't return false in 'polyfillaction'

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -16,7 +16,6 @@ Handlebars.registerHelper('polyfillaction', function(tags) {
   if(tags && tags.indexOf('fallback') > -1) {
     return 'with <b class=fallback>fallback</b>';
   }
-  return false;
 });
 
 Handlebars.registerHelper('featuretag', function(feature) {


### PR DESCRIPTION
If a polyfill or fallback isn't necessary, the little status text displays 'false'.

![old](https://cloud.githubusercontent.com/assets/1001186/4992492/7811b4da-69a1-11e4-93f5-f53d9b8637d4.png)
![new](https://cloud.githubusercontent.com/assets/1001186/4992491/78116d36-69a1-11e4-8bf3-786c0d625a79.png)
