### PR TITLE
Update Drag and Drop article and add a new post for proposed dropzone attr

### DIFF
--- a/posts/dragndrop.md
+++ b/posts/dragndrop.md
@@ -2,8 +2,8 @@ feature: drag n drop
 status: caution
 tags: polyfill nomobile
 kind: api
-polyfillurls: [dropzone](https://github.com/stevendwood/html5-dropzone), [dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView)
+polyfillurls: [html5-dropzone](https://github.com/stevendwood/html5-dropzone), [dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView)
 
-Drag and Drop has been standardized in HTML5 based on Internet Explorer's original implementation. Therefore, it already has wide desktop support, but many feel frustrated when using the API. You may want to use jQuery UI Draggable (or another JavaScript library) to handle this for you. Meanwhile the proposed [`dropzone`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dropzone-attribute) attribute will improve the situation as it gains browser support.
+Drag and Drop has been standardized in HTML5 based on Internet Explorer's original implementation. Therefore, it already has wide desktop support, but many feel frustrated when using the API. You may want to use jQuery UI Draggable (or another JavaScript library) to handle this for you, however, if you want to work with data dragged from other applications or if you want to be able to drag data between browser tabs/windows, HTML5 drag and drop is the only game in town.  Meanwhile the proposed [`dropzone`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dropzone-attribute) attribute will improve the situation as it gains browser support, you can use [html5-dropzone](https://github.com/stevendwood/html5-dropzone) in the meantime.
 
 There is not much mobile support currently.

--- a/posts/dragndrop.md
+++ b/posts/dragndrop.md
@@ -1,9 +1,15 @@
 feature: drag n drop
-status: caution
+status: use
 tags: polyfill nomobile
 kind: api
-polyfillurls: [html5-dropzone](https://github.com/stevendwood/html5-dropzone), [dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView)
+polyfillurls: [dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView), [setDragImage-IE](https://github.com/MihaiValentin/setDragImage-IE)
 
-Drag and Drop has been standardized in HTML5 based on Internet Explorer's original implementation. Therefore, it already has wide desktop support, but many feel frustrated when using the API. You may want to use jQuery UI Draggable (or another JavaScript library) to handle this for you, however, if you want to work with data dragged from other applications or if you want to be able to drag data between browser tabs/windows, HTML5 drag and drop is the only game in town.  Meanwhile the proposed [`dropzone`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dropzone-attribute) attribute will improve the situation as it gains browser support, you can use [html5-dropzone](https://github.com/stevendwood/html5-dropzone) in the meantime.
+Drag and Drop has been standardized in HTML5 based on Internet Explorer's original implementation.  The HTML5 spec adds additional capabilities including making any element draggable with the [`draggable`](http://www.w3.org/TR/2010/WD-html5-20101019/dnd.html#the-draggable-attribute) attribute, and being able to work with files. 
 
-There is not much mobile support currently.
+It already has wide desktop support, but many feel frustrated when using the API. You may want to use jQuery UI Draggable (or another JavaScript library) to handle this for you, however if you want to work with data dragged from other applications or if you want to be able to drag data between browser tabs/windows, then HTML5 drag and drop is the only option.  Indicating that an element accepts drops causes particular frustration since there are so many events that need to be cancelled, however the proposed [`dropzone`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dropzone-attribute) attribute will improve the situation as it gains browser support.
+
+No versions of Internet Explorer currently support the [`DataTransfer.setDragImage`](http://www.w3.org/TR/2010/WD-html5-20101019/dnd.html#dom-datatransfer-setdragimage) method. All versions of Internet Explorer will also throw an exception when the [`DataTransfer.setData`](http://dev.w3.org/html5/spec-preview/dnd.html#dom-datatransfer-setdata) method is invoked with a format other than "Text" or "Url". 
+
+Internet Explorer 10 and above add support for [`DataTransfer.files`](http://dev.w3.org/html5/spec-preview/dnd.html#dom-datatransfer-files), however for older versions of IE you'll need to use one of the suggested polyfills if the use case you want to support involves dragging local files.
+
+Currently the only mobile platforms supporting HTML5 drag and drop are Internet Explorer Mobile 10 and upwards.

--- a/posts/dragndrop.md
+++ b/posts/dragndrop.md
@@ -2,7 +2,7 @@ feature: drag n drop
 status: caution
 tags: polyfill nomobile
 kind: api
-polyfillurls:[dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView)
+polyfillurls: [dropzone](https://github.com/stevendwood/html5-dropzone), [dropfile](https://github.com/MrSwitch/dropfile), [fileSaver](https://github.com/eligrey/FileSaver.js), [jDataView](https://github.com/vjeux/jDataView)
 
 Drag and Drop has been standardized in HTML5 based on Internet Explorer's original implementation. Therefore, it already has wide desktop support, but many feel frustrated when using the API. You may want to use jQuery UI Draggable (or another JavaScript library) to handle this for you. Meanwhile the proposed [`dropzone`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dropzone-attribute) attribute will improve the situation as it gains browser support.
 

--- a/posts/dropzone.md
+++ b/posts/dropzone.md
@@ -1,0 +1,10 @@
+feature: dropzone
+status: avoid
+tags: polyfill nomobile
+kind: html
+polyfillurls: https://github.com/stevendwood/html5-dropzone
+moreurl: https://html.spec.whatwg.org/multipage/interaction.html#the-dropzone-attribute
+
+The `dropzone` attribute can be added to any HTML element, and indicates that the element is a drop target.  Working with the native drag and drop API can be a pain, due in part to the number of events that you need to listen for and cancel in order to tell the browser whether an element accepts a drop.  The `dropzone` attribute declaritvely tells the browser that an element accepts a drop when the dragged data matches the kind and type specified by the attribute value.
+
+Unfortunately it has not been implemented by any browser vendor, and at this stage it's not clear whether it ever will.  However the [html5-dropzone](https://github.com/stevendwood/html5-dropzone) library provides a polyfill for IE10+ and Chrome/Safari/Firefox if you are interested in using it.


### PR DESCRIPTION
Shameless self promotion, but i recently spent months wrestling with the HTML5 drag and drop API on various browsers and ended up creating a polyfill for the [dropzone] attribute, as far as I can tell the only person foolish enough to bother with it.  There are a load of other fixes for various issues you can expect to face when using the dnd API for any non trivial use.  Feel free to take a look at my [stackoverflow] (http://stackoverflow.com/users/1906362/woody) (I was on here a lot asking about and answering questions on dnd) to see if you think my contributions are worthy of your fine site.