### PR TITLE
Add explicit 'https' to GitHub API url

### DIFF
--- a/src/js/gh-activity.js
+++ b/src/js/gh-activity.js
@@ -23,7 +23,7 @@
     req.send();
   };
 
-  request('//api.github.com/repos/h5bp/html5please/commits', function(error, data) {
+  request('https://api.github.com/repos/h5bp/html5please/commits', function(error, data) {
     if (error) {
       throw error;
     }


### PR DESCRIPTION
Request to 'http' redirects to 'https' with 307 status.
Some browsers (like Safari 7.1 or Firefox 35.0.1) don't follow
redirect for cross-origin requests and print error like this:
```
XMLHttpRequest cannot load
http://api.github.com/repos/h5bp/html5please/commits. No
'Access-Control-Allow-Origin' header is present on the requested
resource. Origin 'http://html5please.com' is therefore not allowed
access.
```