### PR TITLE
Replace execSync Node module with sync-exec

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var $ = require('gulp-load-plugins')();
 
 $.del = require('del');
 $.open = require('open');
-$.execSync = require('execSync');
+$.execSync = require('sync-exec');
 
 gulp.task('build', ['render', 'styles'], function() {
   $.del.sync('build');
@@ -48,7 +48,7 @@ gulp.task('watch', function() {
 });
 
 gulp.task('styles', function() {
-  $.execSync.run('compass compile .');
+  $.execSync('compass compile .');
 });
 
 gulp.task('serve', ['render', 'styles'], function() {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "async": "*",
     "backbone": "^1.1.2",
     "del": "^1.1.1",
-    "execSync": "^1.0.2",
+    "sync-exec": "^0.5.0",
     "gulp": "^3.8.11",
     "gulp-connect": "^2.2.0",
     "gulp-if": "^1.2.5",


### PR DESCRIPTION
Using Node 0.12.0 with execSync 1.0.2 produces the following error:
Native code compile failed!!

Since execSync fails to properly install, none of the Gulp tasks are able to run:
Cannot find module './build/Release/shell'
