### PR TITLE
Use child_process of nodejs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var $ = require('gulp-load-plugins')();
 
 $.del = require('del');
 $.open = require('open');
-$.execSync = require('execSync');
+$.execSync = require('child_process').execSync || require('execSync').exec;
 
 gulp.task('build', ['render', 'styles'], function() {
   $.del.sync('build');
@@ -48,7 +48,7 @@ gulp.task('watch', function() {
 });
 
 gulp.task('styles', function() {
-  $.execSync.run('compass compile .');
+  $.execSync('compass compile .');
 });
 
 gulp.task('serve', ['render', 'styles'], function() {


### PR DESCRIPTION
Update the code to use child_process available from node first. If it is somehow not available, then, use execSync as fallback.

If this looks good, for future, we can remove the execSync dependency too.