### PR TITLE
Add link to cross-browser Fullscreen API wrapper

### DIFF
--- a/posts/fullscreen.md
+++ b/posts/fullscreen.md
@@ -4,4 +4,8 @@ tags: fallback
 kind: api
 polyfillurls: [jQuery Fullscreen Plugin](https://github.com/kayahr/jquery-fullscreen-plugin)
 
-The Full Screen API is currently only available in the latest versions of Chrome, Firefox and Opera. A jQuery plugin is available which contains an optional fallback to a minimal-chrome browser window when the Full Screen API is unavailable. Use as a progressive enhancement for those select browsers only.
+The Full Screen API is currently only available in the latest versions of Chrome, Firefox and Opera.
+
+[screenfull.js](https://github.com/sindresorhus/screenfull.js/) is a simple, dependency free wrapper for cross-browser usage of the JavaScript Fullscreen API.
+
+A jQuery plugin is available which contains an optional fallback to a minimal-chrome browser window when the Full Screen API is unavailable. Use as a progressive enhancement for those select browsers only.


### PR DESCRIPTION
… screenfull.js is a simple dependency free wrapper for cross-browser usage of the JavaScript Fullscreen API.

It helps you handling those (weird … huhu IE :wave:) vendor prefixes when using the API.