### PR TITLE
Adjust text for css-regions

### DIFF
--- a/posts/regions.md
+++ b/posts/regions.md
@@ -4,4 +4,4 @@ tags: none
 kind: css
 polyfillurls:
 
-CSS Regions is in active development. As a result, the syntax is in flux. A polyfill based on an older syntax exists, but we recommend you hold your horses till this spec sees some stability and 3 or more implementations.
+CSS Regions is a layout module that is depricated. It is no longer supported by the common browsers like Chrome, Firefox and Safari.


### PR DESCRIPTION
Describe regions as deprecated since is was still called as "in-development".