### PR TITLE
Update ECMAScript 6

### DIFF
--- a/posts/es6.md
+++ b/posts/es6.md
@@ -17,5 +17,4 @@ If you have to support Internet Explorer or would like to use the latest ECMAScr
 - [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html) to polyfill new built-in methods
 
 Note:  
-*@babel/polyfill* is a simple solution which wraps *core-js* and includes each and every polyfill no matter if you actually need it.
-You should consider using *core-js* directly to import just the polyfills you need to receive a better performance due to smaller JavaScript bundle files.
+You should use *[@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html)* with *[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env)* and the `useBuiltIns` option so that it doesn't include the whole polyfill. Otherwise you can use *[core-js](https://github.com/zloirock/core-js)* directly to import just the polyfills you need to receive a better performance due to smaller JavaScript bundle files.

--- a/posts/es6.md
+++ b/posts/es6.md
@@ -1,12 +1,21 @@
-feature: ECMAScript 6
+feature: ECMAScript 6 (and above)
 status: use
 tags: polyfill
 kind: js
-polyfillurls: [Babel](https://babeljs.io/), [Traceur](https://github.com/google/traceur-compiler), [ES6-shim](https://github.com/paulmillr/es6-shim)
-moreurl: http://www.2ality.com/2013/07/es6-modules.html
+polyfillurls: [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html), [core-js](https://github.com/zloirock/core-js)
+moreurl: https://ponyfoo.com/articles/es6
 
-ECMAScript version 6 is the upcoming version of JavaScript that brings new features and heavy syntax changes. 
+ECMAScript version 6 was a major update of JavaScript that brought new features and lots of syntactical additions.
+ES6 was later renamed to ES2015 to reflect the changes in the release cycle. Since 2015 there are yearly releases with smaller feature sets.
 
-Currently not any browser supports all ES6 features. You can check the [ES6 compatibility table](https://kangax.github.io/compat-table/es6/) for details.
+ES6 is pretty well supported by the latest browsers.
+You can check the [ES6 compatibility table](https://kangax.github.io/compat-table/es6/) for details about the latest versions.
 
-There is the [ES6-shim](https://github.com/paulmillr/es6-shim) project that attempts to shim a subset of ES6 however this subset is quite small, it does not subset any new syntax. If you want to take adventage of the new syntax today, you can consider an ES6 to ES5 compiler like [Babel](https://babeljs.io/) or [Traceur](https://github.com/google/traceur-compiler).
+If you have to support Internet Explorer or would like to use the latest ECMAScript features you will have to use:
+
+- [Babel](https://babeljs.io/) as a tool to compile newer syntax to ES5
+- [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html) to polyfill new built-in methods
+
+Note:  
+*@babel/polyfill* is a simple solution which wraps *core-js* and includes each and every polyfill no matter if you actually need it.
+You should consider using *core-js* directly to import just the polyfills you need to receive a better performance due to smaller JavaScript bundle files.


### PR DESCRIPTION
Refering to #409 

Summary:

- Rename feature to »ECMAScript 6 (and above)«
- Add Info about the name change and the release process
- Remove [Traceur](https://github.com/google/traceur-compiler)
- Remove ES6-shim
- Add [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill.html), [core-js](https://github.com/zloirock/core-js)
- Update `moreurl` from <http://www.2ality.com/2013/07/es6-modules.html> to <https://ponyfoo.com/articles/es6>