### PR TITLE
HTTPS link to html5please.com from 404 page

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -56,7 +56,6 @@
   <body>
     <h1>Page Not Found</h1>
     <p>Sorry, but the page you were trying to view does not exist.</p>
-    <p><a href="http://html5please.com/">Back to HTML5 Please →</a></p>
+    <p><a href="https://html5please.com/">Back to HTML5 Please →</a></p>
   </body>
 </html>
-<!-- IE requires 512+ bytes: http://www.404-error-page.com/404-error-page-too-short-problem-microsoft-ie.shtml -->


### PR DESCRIPTION
and remove this dead link
`<!-- IE requires 512+ bytes: http://www.404-error-page.com/404-error-page-too-short-problem-microsoft-ie.shtml -->`