### PR TITLE
This changes caniuse.com URL to prevent a redirect

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -37,7 +37,7 @@ var paths = {
   template: './src/template.html',
   posts: './posts',
   githuburl: 'https://github.com/h5bp/html5please/blob/master/posts/',
-  caniuseurl: 'https://caniuse.com/'
+  caniuseurl: 'https://caniuse.com/#feat='
 };
 
 // Tag Array


### PR DESCRIPTION
This changes the automatic 'View browser share%' caniuse.com URLs to prevent a redirect
e.g. from https://caniuse.com/border-radius to https://caniuse.com/#feat=border-radius