### PR TITLE
Remove unneeded defer from Google Analytics snippet

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -105,6 +105,6 @@
       ga('set', 'anonymizeIp', true);
       ga('send','pageview')
       </script>
-      <script src="https://www.google-analytics.com/analytics.js" defer async></script>
+      <script src="https://www.google-analytics.com/analytics.js" async></script>
   </body>
 </html>


### PR DESCRIPTION
has no use if analytics is at the bottom of the page and is no longer recommended by HTML5Boilerplate - and saves 6 bytes :-)