### PR TITLE
Remove Node v8 (no longer supported)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ git:
 language: node_js
 
 node_js:
-  - 8
   - 10
 
 sudo: false


### PR DESCRIPTION
REF: https://nodejs.org/en/about/releases/